### PR TITLE
Feature/relevant-recipes-button

### DIFF
--- a/data/harvesting-components.json
+++ b/data/harvesting-components.json
@@ -363,7 +363,7 @@
     {
         "creatureType": "Beast",
         "name": "Beast Stinger",
-        "dc": 15,
+        "dc": 5,
         "id": "QFG2nvKjMeb3A9in",
         "img": "icons/creatures/claws/claw-curved-jagged-yellow.webp",
         "crafting": true,

--- a/lang/en.json
+++ b/lang/en.json
@@ -24,6 +24,7 @@
         "ChatRollCheckInstructions": "Roll your combined check and enter the total into the harvest window.",
         "ChatHarvestTableMessage": "Harvest DC Table for {creatureName}",
         "ChatComponentsInstructions": "Discuss what you would like to attempt to harvest and what order. Each additional item you attempt to harvest will increase the DC.",
+        "ShowRelevantRecipes": "Show Relevant Recipes",
         "ChatComponentsMessage": "The following items can be harvested from {creatureName}:",
         "CraftControl": "Crafting Recipes",
         "CraftWindowTitle": "Heliana's Crafting Recipes",

--- a/scripts/RecipeDatabase.js
+++ b/scripts/RecipeDatabase.js
@@ -93,17 +93,24 @@ export class RecipeDatabase {
     }
 
     /**
-     * Searches all recipes to find
+     * Searches all recipes to find.  Default behaviour returns all recipes if no search string is provided.
      *
      * @param {string} text Search string
+     * @param {boolean} [matchAll=true] Whether to match all keywords (AND logic) or any keyword (OR logic)
+     * @param {string} [delimiter=" "] Delimiter used to split the search string into keywords.  " " for AND logic, "," for OR logic
      *
      * @returns {any[]} results
      */
-    searchItems(text) {
-        let keywords = text.toLowerCase().split(" ");
-
+    searchItems(text, matchAll = false, delimiter = ",") {
+        let keywords = text.toLowerCase().split(delimiter)
+        keywords = keywords.map(word => word.trim()).filter(word => word.length > 0);
+        if (keywords.length === 0) return this._recipes;
         return this._recipes.filter(r => {
-            return keywords.every(word => (r.searchText.includes(word)));
+            if (matchAll) {
+                return keywords.every(word => (r.searchText.includes(word)));
+            } else {
+                return keywords.some(word => (r.searchText.includes(word)));
+            }
         });
     }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,6 +3,8 @@ import { loadModules } from "./utils/loadModules.js";
 import { bindSceneControlButtons } from "./utils/bindSceneControlButtons.js";
 import { initializeDatabases } from "./utils/initializeDatabases.js";
 import { setupModuleAPI } from "./utils/setupModuleAPI.js";
+import { relevantRecipes } from "./utils/relevantRecipes.js";
+
 
 Hooks.on("setup", setupModuleAPI);
 
@@ -12,3 +14,5 @@ Hooks.on("getSceneControlButtons", bindSceneControlButtons);
 
 Hooks.on("getHarvestWindowHeaderButtons", bindStatisticsButton);
 Hooks.on("getCraftingWindowHeaderButtons", bindStatisticsButton);
+
+Hooks.on('renderChatMessage', relevantRecipes);

--- a/scripts/utils/relevantRecipes.js
+++ b/scripts/utils/relevantRecipes.js
@@ -1,0 +1,19 @@
+import CraftingWindow from "../windows/CraftingWindow.js";
+
+//Should be called with Hooks.on('renderChatMessage', relevantComponents);
+//Injects an on click so that the relevant recipes are shown when the button is clicked.
+export function relevantRecipes(message, html, messageData) {
+    const RelevantRecipesButton = html.find(".helianas-harvest-relevant-recipes-button");
+    if (RelevantRecipesButton.length === 0) {
+        return
+    }
+
+    let searchText = RelevantRecipesButton[0].title;
+
+    RelevantRecipesButton.on("click", event => {
+        event.preventDefault();
+        const { recipeDatabase } = game.modules.get("helianas-harvesting").api;
+        const cw = new CraftingWindow(recipeDatabase, searchText=searchText);
+        cw.render(true);
+    });
+};

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -7,11 +7,13 @@ export default class CraftingWindow extends Application {
      *
      * @param {RecipeDatabase} recipeDatabase
      * @param {ActorToken} token
+     * @param {string} searchText
      */
-    constructor(recipeDatabase) {
+    constructor(recipeDatabase, searchText = "") {
         super();
 
         this.recipeDatabase = recipeDatabase;
+        this.searchText = searchText
     }
 
     static get defaultOptions() {
@@ -34,8 +36,9 @@ export default class CraftingWindow extends Application {
 
     /**
      * Search Text Field
+     * (This has been moved to the class constructor to allow the search text to be passed in from other functions)
      */
-    searchText = "";
+    //searchText = "";
 
     #activeElementId = false;
     #cursorPosition = { start: 0, end: 0 };

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -55,6 +55,7 @@ export default class CraftingWindow extends Application {
     getData() {
         let data = super.getData();
         data.rarityNames = game.system.config.itemRarity;
+        data.displaySearchBar = game.user.isGM;
 
         data.recipes = this.recipeDatabase
             .searchItems(this.searchText)

--- a/scripts/windows/HarvestWindow.js
+++ b/scripts/windows/HarvestWindow.js
@@ -194,17 +194,24 @@ export default class HarvestWindow extends Application {
   }
 
   shareComponents() {
+    let searchQuery = "";
+
     let message = `<p>${game.i18n.format("HelianasHarvest.ChatComponentsMessage", {creatureName: this.formData.creatureName})}</p>`;
     message += `<ul>`;
 
     this.formData.getHarvestComponents().forEach(item => {
       message += `<li> ${item.name} (DC ${item.dc}) x ${item.count}`;
+      searchQuery += item.name + ",";
     });
 
     message += `</ul>
-      <p>${game.i18n.localize("HelianasHarvest.ChatComponentsInstructions")}</p>`;
+      <p>${game.i18n.localize("HelianasHarvest.ChatComponentsInstructions")}</p>
+      <button class="helianas-harvest-relevant-recipes-button" title="${searchQuery}">${game.i18n.localize("HelianasHarvest.ShowRelevantRecipes")}</button>
+      `;
 
     this.sendChatMessage(message);
+
+    this.formData.getHarvestComponents();
   }
 
   getAssessmentSkill() {

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -2,7 +2,7 @@
   <div class="form-group">
     <div class="form-fields">
       <input
-        type="text"
+        type={{ifThen displaySearchBar "text" "hidden"}}
         class="managed-input debounce form-control"
         id="recipe-search"
         value="{{searchText}}"


### PR DESCRIPTION
As a player, when the GM clicks the harvesting "Share All Components" button, I want to be able to click a button and view all recipes which use those components to help decide which to attempt to harvest.

The "Heliana's Crafting Recipes" windows search has been improved.  It now uses a comma "," as the delimiter instead of a space " ".  Now it will use OR logic instead of AND logic to make the search.  If no search term is provided, all recipes will be shown.

The message sent to the chat when the "Share All Components" button is pressed now contains a button to "Show Relevant Recipes".  This button's title (seen when hovering over the button) contains a search query for the list of components available for harvest, once clicked the "Heliana's Crafting Recipes" window will open, displaying all recipes containing any of those components.

The search bar of the "Heliana's Crafting Recipes" window will be hidden if opened by a player.