### PR TITLE
Feature/show held components

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -31,6 +31,7 @@
         "ItemPriceHeader": "Value",
         "RecipeMetatag": "Metatag",
         "RequiredComponents": "Required Components",
+        "HeldComponents": "Held Components",
         "RecipeSearch": "Search Recipes",
         "CraftingCreatedItemNotice": "Sent {itemName} to {actorName}",
         "PlayerSelectWindowTitle": "Select a Player",

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,8 @@
         "RecipeMetatag": "Metatag",
         "RequiredComponents": "Required Components",
         "HeldComponents": "Held Components",
+        "InInventory": "Held in Inventory",
+        "FilterComponents": "View Only Held Components",
         "RecipeSearch": "Search Recipes",
         "CraftingCreatedItemNotice": "Sent {itemName} to {actorName}",
         "PlayerSelectWindowTitle": "Select a Player",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,13 @@
 {
     "HelianasHarvest" : {
+        "Settings": {
+            "HeldComponents": {
+                "HeldComponentsName": "Display Held Components",
+                "HeldComponentsHint": "If enabled, an extra column will be added to the crafting window recipe table to display a breakdown of who is holding the required components.  This also adds a button to toggle filtering held components. \n Recommended - Client specific, may result in the table loading slower",
+                "PartyInventorySupportName": "Party-Inventory Module Support",
+                "PartyInventorySupportHint": "If enabled, items within the Party-Inventory module will be included in the Held Components column. \nRequires Display Held Components to be enabled.\nRequires https://github.com/teroparvinen/foundry-party-inventory\n"
+            }
+        },
         "CreatureTypeLabel": "Creature Type",
         "CreatureNameLabel": "Creature Name",
         "CreatureCRLabel": "Creature CR Rating",

--- a/scripts/ComponentDatabase.js
+++ b/scripts/ComponentDatabase.js
@@ -131,6 +131,7 @@ export class ComponentDatabase {
             "flags": {
                 "helianas-harvesting": {
                     "id": item.id,
+                    "name": item.name,
                     "source": creatureName
                 }
             }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -12,3 +12,11 @@ Hooks.on("getSceneControlButtons", bindSceneControlButtons);
 
 Hooks.on("getHarvestWindowHeaderButtons", bindStatisticsButton);
 Hooks.on("getCraftingWindowHeaderButtons", bindStatisticsButton);
+
+Handlebars.registerHelper('ifContains', (string1, string2, options) => {
+    return (string1.includes(string2)) ? options.fn(this) : options.inverse(this);
+});
+
+Handlebars.registerHelper('ifEquals', (string1, string2, options) => {
+    return (string1 === string2) ? options.fn(this) : options.inverse(this);
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -14,7 +14,7 @@ Hooks.on("getHarvestWindowHeaderButtons", bindStatisticsButton);
 Hooks.on("getCraftingWindowHeaderButtons", bindStatisticsButton);
 
 Handlebars.registerHelper('ifContains', (string1, string2, options) => {
-    return (string1.includes(string2)) ? options.fn(this) : options.inverse(this);
+    return (string1.toLowerCase().includes(string2.toLowerCase())) ? options.fn(this) : options.inverse(this);
 });
 
 Handlebars.registerHelper('ifEquals', (string1, string2, options) => {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,6 +3,9 @@ import { loadModules } from "./utils/loadModules.js";
 import { bindSceneControlButtons } from "./utils/bindSceneControlButtons.js";
 import { initializeDatabases } from "./utils/initializeDatabases.js";
 import { setupModuleAPI } from "./utils/setupModuleAPI.js";
+import { setupSettings } from "./utils/settings.js";
+
+Hooks.on("init", setupSettings);
 
 Hooks.on("setup", setupModuleAPI);
 

--- a/scripts/utils/partyInventorySupport.js
+++ b/scripts/utils/partyInventorySupport.js
@@ -1,0 +1,54 @@
+// This function is used to detect the quantity of an item in a string.  Copied from the party-inventory module.
+function detectQuantity(input) {
+    if (input) {
+        const re =/(?:(\d+)\s+)?(.+?)(?:\s+\((\d+)\)|$)/;
+        const matches = input.match(re);
+
+        if (matches) {
+            if (matches[1]) {
+                return { name: matches[2], quantity: parseInt(matches[1]), style: 'prefix' };
+            } else if (matches[3]) {
+                return { name: matches[2], quantity: parseInt(matches[3]), style: 'suffix' };
+            }
+        }
+    }
+
+    return { name: input, quantity: 1 };
+}
+
+
+export default function getPartyInventoryItems() {
+    let partyInventoryAll
+    try {
+        partyInventoryAll = game.settings.get("party-inventory", 'scratchpad');
+    }catch (error) {
+        console.error("Unable to get party-inventory", error);
+        console.warn("Party-Inventory module not found. Party-Inventory support setting must be disabled.");
+        return {items: {}, order: []};
+    }
+    let partyInventory = {items: {}, order: []};
+
+    for (let order of partyInventoryAll.order) {
+        console.log("Party Inventory order", order);
+        console.log("Party Inventory item", partyInventoryAll.items[order]);
+        let item = partyInventoryAll.items[order];
+        if (!item.name) {
+            console.warn("Item without a name detected and skipped:", item);
+        } else {
+            if (!item.system){
+                item.system = {};
+            }
+            item.system.quantity = detectQuantity(item.name).quantity;
+            //if (!item.parent) {
+            console.log("Item.parent", item.parent);
+            item.parent = {name: "Party-Inventory2"};
+            console.log("Item.parent.name", item.parent.name);
+            //}
+
+            partyInventory.order.push(order);
+            partyInventory.items[order] = item;
+        }
+    }
+    console.warn("Party Inventory", partyInventory);
+    return partyInventory;
+}

--- a/scripts/utils/partyInventorySupport.js
+++ b/scripts/utils/partyInventorySupport.js
@@ -17,6 +17,9 @@ function detectQuantity(input) {
 }
 
 
+                    // Search for components in the party-inventory module
+                    // https://github.com/teroparvinen/foundry-party-inventory
+                    // game.modules.get("party-inventory", 'scratchpad');
 export default function getPartyInventoryItems() {
     let partyInventoryAll
     try {
@@ -29,8 +32,6 @@ export default function getPartyInventoryItems() {
     let partyInventory = {items: {}, order: []};
 
     for (let order of partyInventoryAll.order) {
-        console.log("Party Inventory order", order);
-        console.log("Party Inventory item", partyInventoryAll.items[order]);
         let item = partyInventoryAll.items[order];
         if (!item.name) {
             console.warn("Item without a name detected and skipped:", item);
@@ -39,16 +40,12 @@ export default function getPartyInventoryItems() {
                 item.system = {};
             }
             item.system.quantity = detectQuantity(item.name).quantity;
-            //if (!item.parent) {
-            console.log("Item.parent", item.parent);
-            item.parent = {name: "Party-Inventory2"};
-            console.log("Item.parent.name", item.parent.name);
-            //}
-
+            if (!item.parent) {
+                item.parent = {name: "Party-Inventory"};
+            }
             partyInventory.order.push(order);
             partyInventory.items[order] = item;
         }
     }
-    console.warn("Party Inventory", partyInventory);
     return partyInventory;
 }

--- a/scripts/utils/settings.js
+++ b/scripts/utils/settings.js
@@ -1,0 +1,39 @@
+export function setupSettings() {
+    // Populate the settings page for the module
+    // settings can be accessed with:
+    // game.settings.get("helianas-harvesting", "heldComponents"); // returns true
+
+    game.settings.register("helianas-harvesting", "heldComponents", {
+        name: "HelianasHarvest.Settings.HeldComponents.HeldComponentsName",
+        hint: "HelianasHarvest.Settings.HeldComponents.HeldComponentsHint",
+        scope: "client",
+        config: true,
+        type: new foundry.data.fields.BooleanField(),
+        default: true,
+        requiresReload: true
+    });
+
+    if(game.modules.get("party-inventory")){
+        game.settings.register("helianas-harvesting", "partyInventorySupport", {
+            name: "HelianasHarvest.Settings.HeldComponents.PartyInventorySupportName",
+            hint: "HelianasHarvest.Settings.HeldComponents.PartyInventorySupportHint",
+            scope: "world",
+            config: true,
+            type: new foundry.data.fields.BooleanField(),
+            default: game.modules.get("party-inventory").active
+        });
+    }else{
+        game.settings.register("helianas-harvesting", "partyInventorySupport", {
+            name: "HelianasHarvest.Settings.HeldComponents.PartyInventorySupportName",
+            hint: "HelianasHarvest.Settings.HeldComponents.PartyInventorySupportHint",
+            scope: "world",
+            config: true,
+            type: new foundry.data.fields.BooleanField(),
+            default: false
+        });
+    }
+
+
+
+
+}

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -57,6 +57,10 @@ export default class CraftingWindow extends Application {
             .searchItems(this.searchText)
             .sort((a, b) => a.name.localeCompare(b.name));
         data.searchText = this.searchText;
+        data.test = "testdata";
+        data.characters = game.actors.filter(a => a.type === "character")
+        console.log("data.characters:");
+        console.log(data.characters);
         return data;
     }
 

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -58,6 +58,26 @@ export default class CraftingWindow extends Application {
             .sort((a, b) => a.name.localeCompare(b.name));
         data.searchText = this.searchText;
         data.characters = game.actors.filter(a => a.type === "character")
+        data = this.mapHeldComponents(data);
+        return data;
+    }
+
+    mapHeldComponents(data) {
+        //Is this logic best here or in ComponentDatabase.js?
+        //Would filter be better than contains?
+        data.recipes.forEach(recipe => {
+            recipe.components.forEach(component => {
+                let heldComponents = [];
+                data.characters.forEach(character => {
+                    character.items.forEach(item => {
+                        if (item.name.toLowerCase().includes(component.name.toLowerCase())){
+                            heldComponents.push(item);
+                        }
+                    });
+                });
+                component.held = heldComponents;
+            });
+        });
         return data;
     }
 

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -78,12 +78,15 @@ export default class CraftingWindow extends Application {
             recipe.components.forEach(component => {
                 component.held = {
                     items : [],
-                    get count() {return this.items.length;}
+                    get count() {
+                        let quantity = 0;
+                        this.items.forEach(item => {quantity += item.system.quantity});
+                        return quantity;
+                    }
                 };
                 data.characters.forEach(character => {
                     component.held.items = component.held.items.concat(character.items.filter(item =>
-                        item.name.toLowerCase().includes(component.name.toLowerCase())
-                    ));
+                        item.name.toLowerCase().includes(component.name.toLowerCase())));
                 });
             });
         });

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -57,10 +57,7 @@ export default class CraftingWindow extends Application {
             .searchItems(this.searchText)
             .sort((a, b) => a.name.localeCompare(b.name));
         data.searchText = this.searchText;
-        data.test = "testdata";
         data.characters = game.actors.filter(a => a.type === "character")
-        console.log("data.characters:");
-        console.log(data.characters);
         return data;
     }
 

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -64,18 +64,14 @@ export default class CraftingWindow extends Application {
 
     mapHeldComponents(data) {
         //Is this logic best here or in ComponentDatabase.js?
-        //Would filter be better than contains?
         data.recipes.forEach(recipe => {
             recipe.components.forEach(component => {
-                let heldComponents = [];
+                component.held = [];
                 data.characters.forEach(character => {
-                    character.items.forEach(item => {
-                        if (item.name.toLowerCase().includes(component.name.toLowerCase())){
-                            heldComponents.push(item);
-                        }
-                    });
+                    component.held = component.held.concat(character.items.filter(item =>
+                        item.name.toLowerCase().includes(component.name.toLowerCase())
+                    ));
                 });
-                component.held = heldComponents;
             });
         });
         return data;

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -104,13 +104,7 @@ export default class CraftingWindow extends Application {
                         item.name.toLowerCase().includes(componentLowerCase)));
                 });
                 if(game.settings.get("helianas-harvesting", "heldComponents") && game.settings.get("helianas-harvesting", "partyInventorySupport")){
-                    // Search for components in the party-inventory module
-                    // https://github.com/teroparvinen/foundry-party-inventory
-                    // game.modules.get("party-inventory", 'scratchpad');
-
                     // create a for loop to iterate through the properties of the partyInventory.items object
-                    // if the item has a source data property then it is likely dragged from an inventory and will have all the necessary data
-                    // if the item has a sourceData property compare the name of the sourceData.name to the component name
                     // if the name includes the component name then add it to the component.held.items array
 
                     for (let order of partyInventory.order) {
@@ -120,27 +114,10 @@ export default class CraftingWindow extends Application {
                                 component.held.items.push(item);
                             }
                         } catch (error) {
-                            console.warn("Item checking item", item);
+                            console.error("Issue checking item error", error);
+                            console.warn("Issue checking item", item);
                         }
                     }
-
-                    //for (let order of partyInventory.order) {
-                    //    let item = partyInventory.items[order];
-                    //    // ignore items without a name as likely all other properties will also be missing.
-                    //    if (!item.name) {
-                    //        console.warn("skipping", item)
-                    //    }
-                    //    else if (item.sourceData && item.sourceData.name.toLowerCase().includes(componentLowerCase)) {
-                    //        component.held.items.push(item.sourceData);
-                    //    }
-                    //    else if (item.parent && item.system && item.name.toLowerCase().includes(componentLowerCase)) {
-                    //        component.held.items.push(item);
-                    //    }
-                    //    else if (item.name.toLowerCase().includes(componentLowerCase)) {
-                    //        console.warn("Item matches but missing necessary properties to be included", item);
-                    //    }
-                    //}
-
                 }
 
 

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -1,6 +1,7 @@
 import { Config } from "../config.js";
 import PlayerSelectWindow from "./PlayerSelectWindow.js";
 import { RecipeDatabase } from "../RecipeDatabase.js";
+import getPartyInventoryItems from "../utils/partyInventorySupport.js";
 
 export default class CraftingWindow extends Application {
     /**
@@ -44,6 +45,13 @@ export default class CraftingWindow extends Application {
      */
     filterComponentsHeld = false;
 
+    /**
+     * Game settings used to determine if the held components column should be shown
+     * @type {boolean}
+     *
+     */
+    showHeldComponents = game.settings.get("helianas-harvesting", "heldComponents");
+
     #activeElementId = false;
     #cursorPosition = { start: 0, end: 0 };
     #debounceSchedule = false;
@@ -66,16 +74,18 @@ export default class CraftingWindow extends Application {
             .sort((a, b) => a.name.localeCompare(b.name));
         data.searchText = this.searchText;
         data.characters = game.actors.filter(a => a.type === "character")
-        data = this.mapHeldComponents(data);
+        if(game.settings.get("helianas-harvesting", "heldComponents")){data = this.mapHeldComponents(data);}
         data.filterComponentsHeld = this.filterComponentsHeld;
+        data.showHeldComponents = this.showHeldComponents;
         if(this.filterComponentsHeld){data.recipes = this.filterOutRecipes(data.recipes)};
         return data;
     }
 
-    mapHeldComponents(data) {
-
-        let partyInventory = game.settings.get("party-inventory", 'scratchpad');
-        console.log(partyInventory);
+    mapHeldComponents(data){
+        let partyInventory = {items: {}, order: []};
+        if(game.settings.get("helianas-harvesting", "heldComponents") && game.settings.get("helianas-harvesting", "partyInventorySupport")){
+            partyInventory = getPartyInventoryItems();
+        }
 
         //Is this logic best here or in ComponentDatabase.js?
         data.recipes.forEach(recipe => {
@@ -93,35 +103,49 @@ export default class CraftingWindow extends Application {
                     component.held.items = component.held.items.concat(character.items.filter(item =>
                         item.name.toLowerCase().includes(componentLowerCase)));
                 });
-                // Search for components in the party-inventory module
-                // https://github.com/teroparvinen/foundry-party-inventory
-                // game.modules.get("party-inventory", 'scratchpad');
+                if(game.settings.get("helianas-harvesting", "heldComponents") && game.settings.get("helianas-harvesting", "partyInventorySupport")){
+                    // Search for components in the party-inventory module
+                    // https://github.com/teroparvinen/foundry-party-inventory
+                    // game.modules.get("party-inventory", 'scratchpad');
 
-                // create a for loop to iterate through the properties of the partyInventory.items object
-                // if the item has a source data property then it is likely dragged from an inventory and will have all the necessary data
-                // if the item has a sourceData property compare the name of the sourceData.name to the component name
-                // if the name includes the component name then add it to the component.held.items array
-                for (let order of partyInventory.order) {
-                    let item = partyInventory.items[order];
-                    if (item.sourceData && item.sourceData.name.toLowerCase().includes(componentLowerCase)) {
-                        component.held.items.push(item.sourceData);
+                    // create a for loop to iterate through the properties of the partyInventory.items object
+                    // if the item has a source data property then it is likely dragged from an inventory and will have all the necessary data
+                    // if the item has a sourceData property compare the name of the sourceData.name to the component name
+                    // if the name includes the component name then add it to the component.held.items array
+
+                    for (let order of partyInventory.order) {
+                        let item = partyInventory.items[order];
+                        try {
+                            if (item.name.toLowerCase().includes(componentLowerCase)){
+                                component.held.items.push(item);
+                            }
+                        } catch (error) {
+                            console.warn("Item checking item", item);
+                        }
                     }
-                    else if (item.parent && item.system && item.name.toLowerCase().includes(componentLowerCase)) {
-                        component.held.items.push(item);
-                    }
-                    else if (item.name.toLowerCase().includes(componentLowerCase)) {
-                        console.log("manual item", item);
-                        item.system = {quantity: 1};  // quantity may not actually be 1, need to look through how party-inventory calculates quantity
-                        item.parent = {name: "Party-Inventory"};
-                        console.log("manual item additional properties", item);
-                        component.held.items.push(item);
-                    }
+
+                    //for (let order of partyInventory.order) {
+                    //    let item = partyInventory.items[order];
+                    //    // ignore items without a name as likely all other properties will also be missing.
+                    //    if (!item.name) {
+                    //        console.warn("skipping", item)
+                    //    }
+                    //    else if (item.sourceData && item.sourceData.name.toLowerCase().includes(componentLowerCase)) {
+                    //        component.held.items.push(item.sourceData);
+                    //    }
+                    //    else if (item.parent && item.system && item.name.toLowerCase().includes(componentLowerCase)) {
+                    //        component.held.items.push(item);
+                    //    }
+                    //    else if (item.name.toLowerCase().includes(componentLowerCase)) {
+                    //        console.warn("Item matches but missing necessary properties to be included", item);
+                    //    }
+                    //}
+
                 }
 
 
             });
         });
-        console.log(data)
         return data;
     }
 

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -19,6 +19,8 @@
         <th scope="col">{{localize "HelianasHarvest.ItemPriceHeader"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RecipeMetatag"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RequiredComponents"}}</th>
+        <th scope="col">{{localize "HelianasHarvest.HeldComponents1"}}</th>
+        <th scope="col">{{localize "HelianasHarvest.HeldComponents2"}}</th>
       </tr>
     </thead>
     <tbody>
@@ -56,6 +58,21 @@
                 <img src="{{ this.img }}" style="max-height: 1rem"/>
                 <span>{{this.name}}</span>
               </p>
+            {{/each}}
+          </td>
+          <td>
+            {{#each this.components}}
+              {{#each ../../characters}}
+                {{#each this.items}}
+                  {{#ifContains this.name ../../name}}
+                    <p>{{../../name}}:{{../system.quantity}}*{{../name}}</p>
+                  {{/ifContains}}
+                  {{!-- this.name = the item in the actors inventory - {{this.name}}--}}
+                  {{!-- ../name = the actor {{../name}}--}}
+                  {{!-- ../../name = the component in the recipe - {{../../name}}--}}
+                  {{!-- ../../../name = the item to be crafted in the recipe - {{../../../name}}--}}
+                {{/each}}
+              {{/each}}
             {{/each}}
           </td>
         </tr>

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -19,8 +19,9 @@
         <th scope="col">{{localize "HelianasHarvest.ItemPriceHeader"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RecipeMetatag"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RequiredComponents"}}</th>
-        <th scope="col">{{localize "HelianasHarvest.HeldComponents"}}</th>
-        <th scope="col">{{localize "HelianasHarvest.HeldComponents"}}</th>
+        <th scope="col">{{localize "HelianasHarvest.HeldComponents"}}
+          <input type="checkbox" class="helianas-harvesting-module" title="{{localize "HelianasHarvest.FilterComponents"}}" id="filterComponentsHeld" name="filterComponentsHeld" data-dtype="Boolean" {{checked filterComponentsHeld}}>
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -62,6 +63,9 @@
           </td>
           <td>
             {{#each this.components}}
+              {{#if this.held.items}}
+                {{this.held.count}} {{localize "HelianasHarvest.InInventory"}}
+              {{/if}}
               {{#each ../../characters}}
                 {{#each this.items}}
                   {{#ifContains this.name ../../name}}

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -19,7 +19,8 @@
         <th scope="col">{{localize "HelianasHarvest.ItemPriceHeader"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RecipeMetatag"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RequiredComponents"}}</th>
-        <th scope="col">{{localize "HelianasHarvest.HeldComponents1"}}</th>
+        <th scope="col">{{localize "HelianasHarvest.HeldComponents"}}</th>
+        <th scope="col">{{localize "HelianasHarvest.HeldComponents"}}</th>
       </tr>
     </thead>
     <tbody>

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -20,7 +20,6 @@
         <th scope="col">{{localize "HelianasHarvest.RecipeMetatag"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RequiredComponents"}}</th>
         <th scope="col">{{localize "HelianasHarvest.HeldComponents1"}}</th>
-        <th scope="col">{{localize "HelianasHarvest.HeldComponents2"}}</th>
       </tr>
     </thead>
     <tbody>

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -64,8 +64,16 @@
           <td>
             {{#each this.components}}
               {{#if this.held.items}}
-                {{this.held.count}} {{localize "HelianasHarvest.InInventory"}}
+                <p><strong>{{this.held.count}} {{localize "HelianasHarvest.InInventory"}}</p></strong>
+                {{#each this.held.items}}
+                  {{#if this.parent}}
+                    <p>{{this.parent.name}} : {{this.name}} : {{this.system.quantity}}</p>
+          {{!--        {{else}}
+                    <p>party-loot : {{this.name}} : {{this.system.quantity}}</p>  --}}
+                  {{/if}}
+                {{/each}}
               {{/if}}
+
       {{!--
               {{#each ../../characters}}
                 {{#each this.items}}

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -66,17 +66,21 @@
               {{#if this.held.items}}
                 {{this.held.count}} {{localize "HelianasHarvest.InInventory"}}
               {{/if}}
+      {{!--
               {{#each ../../characters}}
                 {{#each this.items}}
                   {{#ifContains this.name ../../name}}
                     <p>{{../../name}}:{{../system.quantity}}*{{../name}}</p>
                   {{/ifContains}}
+      --}}
                   {{!-- this.name = the item in the actors inventory - {{this.name}}--}}
                   {{!-- ../name = the actor {{../name}}--}}
                   {{!-- ../../name = the component in the recipe - {{../../name}}--}}
                   {{!-- ../../../name = the item to be crafted in the recipe - {{../../../name}}--}}
+      {{!--
                 {{/each}}
               {{/each}}
+      --}}
             {{/each}}
           </td>
         </tr>

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -19,9 +19,11 @@
         <th scope="col">{{localize "HelianasHarvest.ItemPriceHeader"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RecipeMetatag"}}</th>
         <th scope="col">{{localize "HelianasHarvest.RequiredComponents"}}</th>
+        {{#if showHeldComponents}}
         <th scope="col">{{localize "HelianasHarvest.HeldComponents"}}
           <input type="checkbox" class="helianas-harvesting-module" title="{{localize "HelianasHarvest.FilterComponents"}}" id="filterComponentsHeld" name="filterComponentsHeld" data-dtype="Boolean" {{checked filterComponentsHeld}}>
         </th>
+        {{/if}}
       </tr>
     </thead>
     <tbody>
@@ -62,34 +64,42 @@
             {{/each}}
           </td>
           <td>
-            {{#each this.components}}
-              {{#if this.held.items}}
-                <p><strong>{{this.held.count}} {{localize "HelianasHarvest.InInventory"}}</p></strong>
-                {{#each this.held.items}}
-                  {{#if this.parent}}
-                    <p>{{this.parent.name}} : {{this.name}} : {{this.system.quantity}}</p>
-          {{!--        {{else}}
-                    <p>party-loot : {{this.name}} : {{this.system.quantity}}</p>  --}}
-                  {{/if}}
-                {{/each}}
-              {{/if}}
+            {{#if ../showHeldComponents}}
+              {{#each this.components}}
+                {{#if this.held.items}}
+                {{!--
+                  {{log this}}
+                  {{log this.held.count}}
+                --}}
+                  <p><strong>{{this.held.count}} {{localize "HelianasHarvest.InInventory"}}</p></strong>
+                  {{#each this.held.items}}
+                    {{log this}}
+                    {{#if this.parent}}
+                      <p>{{this.parent.name}} : {{this.name}} : {{this.system.quantity}}</p>
+            {{!--        {{else}}
+                      <p>party-loot : {{this.name}} : {{this.system.quantity}}</p>  --}}
+                    {{/if}}
+                  {{/each}}
+                {{/if}}
 
-      {{!--
-              {{#each ../../characters}}
-                {{#each this.items}}
-                  {{#ifContains this.name ../../name}}
-                    <p>{{../../name}}:{{../system.quantity}}*{{../name}}</p>
-                  {{/ifContains}}
-      --}}
-                  {{!-- this.name = the item in the actors inventory - {{this.name}}--}}
-                  {{!-- ../name = the actor {{../name}}--}}
-                  {{!-- ../../name = the component in the recipe - {{../../name}}--}}
-                  {{!-- ../../../name = the item to be crafted in the recipe - {{../../../name}}--}}
-      {{!--
+        {{!--
+                {{#each ../../characters}}
+                  {{#each this.items}}
+                    {{#ifContains this.name ../../name}}
+                      <p>{{../../name}}:{{../system.quantity}}*{{../name}}</p>
+                    {{/ifContains}}
+        --}}
+                    {{!-- this.name = the item in the actors inventory - {{this.name}}--}}
+                    {{!-- ../name = the actor {{../name}}--}}
+                    {{!-- ../../name = the component in the recipe - {{../../name}}--}}
+                    {{!-- ../../../name = the item to be crafted in the recipe - {{../../../name}}--}}
+        {{!--
+                  {{/each}}
                 {{/each}}
+                           {{log  this}}
+        --}}
               {{/each}}
-      --}}
-            {{/each}}
+            {{/if}}
           </td>
         </tr>
       {{/each}}

--- a/templates/crafting-window.hbs
+++ b/templates/crafting-window.hbs
@@ -67,37 +67,14 @@
             {{#if ../showHeldComponents}}
               {{#each this.components}}
                 {{#if this.held.items}}
-                {{!--
-                  {{log this}}
-                  {{log this.held.count}}
-                --}}
                   <p><strong>{{this.held.count}} {{localize "HelianasHarvest.InInventory"}}</p></strong>
                   {{#each this.held.items}}
                     {{log this}}
                     {{#if this.parent}}
                       <p>{{this.parent.name}} : {{this.name}} : {{this.system.quantity}}</p>
-            {{!--        {{else}}
-                      <p>party-loot : {{this.name}} : {{this.system.quantity}}</p>  --}}
                     {{/if}}
                   {{/each}}
                 {{/if}}
-
-        {{!--
-                {{#each ../../characters}}
-                  {{#each this.items}}
-                    {{#ifContains this.name ../../name}}
-                      <p>{{../../name}}:{{../system.quantity}}*{{../name}}</p>
-                    {{/ifContains}}
-        --}}
-                    {{!-- this.name = the item in the actors inventory - {{this.name}}--}}
-                    {{!-- ../name = the actor {{../name}}--}}
-                    {{!-- ../../name = the component in the recipe - {{../../name}}--}}
-                    {{!-- ../../../name = the item to be crafted in the recipe - {{../../../name}}--}}
-        {{!--
-                  {{/each}}
-                {{/each}}
-                           {{log  this}}
-        --}}
               {{/each}}
             {{/if}}
           </td>


### PR DESCRIPTION
- Setting to toggle an additional column in the crafting table which will display which actors are holding relevant components for each recipe.
- Setting to toggle support for the Party-Inventory module (https://github.com/teroparvinen/foundry-party-inventory).
- Toggle to filter the crafting table, only displaying recipes which the party have the required components.

Known issue - Items created in party-inventory and moved across to an actor do not appear on the actors sheet but are still found by this module and displayed in the crafting table.  Further testing is needed.